### PR TITLE
Add reusable duplicate finder module and README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,27 @@
-GDSVCHCVKJDSBjvb
-jknknkj
-fubhgiorejjbhjwpeohbjwepo
-yfgergjhoerhhprehyrdiojhopi
-fxchvjhvjhvhjvhvhv
-uoieeueueuytuetjgjteyjytjtejjgjtejetyjjjetyj
-dsjhfbckjdsbgdbslgkjgbdsfkajbgfkjbda,gba
-dvdfsbdsfb
-gpijidjgjesgjiejgiperw
-gjerjgkjnwregnkwrn
-gfhjpjfg[dkhptkwr[ph
-regewghetwghwe
-jhbvhivkjhbkjbkjbjkbkjbkjbkjbk
-jdbfjdbjgbvjdfbgk
-uygiughiuhhohoih
-iuhoihioho
-fdhyvgudfhviosdvp
-fijbvndfppbodflg[pdflbd
-rgegergergergerg
-88498985295989
-jhvbbjkbjkbnk
-ghrthreheh
-sabcjkbsdkjbvlskbv
-eghrtwhrtwhwrthwrth
-kjfbdkfbjsdbvjlsj
-fdkhvuodfhvkknsavfkmsal
-fjkbsrljng;ksrl;g;lsm
-fsgafagfdaga
-vdfsbvdsfbdsfbdsgbgdsb
-ytryufiuy
-sdfghjkl;pgofjbifgnnborgkf
-chvsdhckvs
-fsagsagasgrehgewhtewht
-ghetahjrsjsjhs
-adfgadfgfd
-drhtfhrwt
+# Repolab
+
+A small JavaScript playground repository with a reusable duplicate-finding utility.
+
+## Included utility
+
+### `findDuplicates`
+
+The `two.js` module exports a `findDuplicates(inputArray)` function that returns each duplicated value once, preserving the order in which duplicates are first detected.
+
+#### Example
+
+```js
+const { findDuplicates } = require('./two');
+
+const values = [1, 'apple', 5, 2, 'banana', 5, 1, 'apple'];
+console.log(findDuplicates(values));
+// => [5, 1, 'apple']
+```
+
+## Run the demo
+
+```bash
+node two.js
+```
+
+This prints a sample input array and the duplicates found in it.

--- a/two.js
+++ b/two.js
@@ -1,34 +1,25 @@
 function findDuplicates(inputArray) {
-    // 1. Initialize a Set to store elements we've seen so far.
-    //    Sets only store unique values, allowing for fast O(1) lookups.
-    const seen = new Set();
-    
-    // 2. Initialize a Set to store the duplicate elements found.
-    //    Using a Set here ensures that each duplicate is listed only once, 
-    //    even if it appears multiple times in the input array.
-    const duplicates = new Set();
+  const seen = new Set();
+  const duplicates = new Set();
 
-    // 3. Iterate through the input array
-    for (const item of inputArray) {
-        // Check if the current item is already in the 'seen' Set
-        if (seen.has(item)) {
-            // If it is, we've found a duplicate! Add it to the duplicates Set.
-            duplicates.add(item);
-        } else {
-            // If it's the first time we've seen it, add it to the 'seen' Set.
-            seen.add(item);
-        }
+  for (const item of inputArray) {
+    if (seen.has(item)) {
+      duplicates.add(item);
+    } else {
+      seen.add(item);
     }
+  }
 
-    // 4. Convert the duplicates Set back to an Array and return it.
-    return Array.from(duplicates);
+  return Array.from(duplicates);
 }
 
-// --- Example Usage ---
+module.exports = {
+  findDuplicates,
+};
 
-const data = [1, 'apple', 5, 2, 'banana', 5, 1, 8, 'apple', 10];
-const result = findDuplicates(data);
+if (require.main === module) {
+  const sampleData = [1, 'apple', 5, 2, 'banana', 5, 1, 8, 'apple', 10];
 
-console.log("Input Array:", data);
-console.log("Duplicates Found:", result); 
-// Expected Output: Duplicates Found: [1, 5, 'apple']
+  console.log('Input Array:', sampleData);
+  console.log('Duplicates Found:', findDuplicates(sampleData));
+}


### PR DESCRIPTION
## Summary
- refactor the duplicate finder into a reusable CommonJS export
- keep a small command-line demo when running `node two.js`
- replace the placeholder README content with clear usage instructions

## Why
This makes the repository a little more useful by turning the most substantial script into something that can be imported by other files while also improving discoverability for anyone landing on the repository.