### PR TITLE
Add reusable array chunk utility with example

### DIFF
--- a/chunkArray.js
+++ b/chunkArray.js
@@ -1,0 +1,19 @@
+function chunkArray(inputArray, chunkSize) {
+  if (!Array.isArray(inputArray)) {
+    throw new TypeError('Expected the first argument to be an array.');
+  }
+
+  if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+    throw new TypeError('Chunk size must be a positive integer.');
+  }
+
+  const chunks = [];
+
+  for (let index = 0; index < inputArray.length; index += chunkSize) {
+    chunks.push(inputArray.slice(index, index + chunkSize));
+  }
+
+  return chunks;
+}
+
+module.exports = chunkArray;

--- a/chunkArrayExample.js
+++ b/chunkArrayExample.js
@@ -1,0 +1,7 @@
+const chunkArray = require('./chunkArray');
+
+const sampleItems = ['alpha', 'beta', 'gamma', 'delta', 'epsilon'];
+const chunkedItems = chunkArray(sampleItems, 2);
+
+console.log('Original items:', sampleItems);
+console.log('Chunked items:', chunkedItems);


### PR DESCRIPTION
## Summary
- add a small reusable `chunkArray` helper for splitting arrays into fixed-size groups
- validate inputs so incorrect usage fails clearly
- include a tiny example script showing how to use it

## Why
This adds a practical standalone utility to the repository without overlapping with the existing duplicate-finder refactor work in open pull requests.