### PR TITLE
Add order-preserving unique values utility

### DIFF
--- a/uniqueValues.js
+++ b/uniqueValues.js
@@ -1,0 +1,22 @@
+/**
+ * Return the first occurrence of each value in an array, preserving order.
+ *
+ * @param {unknown[]} values - Values to deduplicate.
+ * @returns {unknown[]} A new array containing only unique values.
+ * @throws {TypeError} When values is not an array.
+ */
+function uniqueValues(values) {
+  if (!Array.isArray(values)) {
+    throw new TypeError("uniqueValues expects an array");
+  }
+
+  return [...new Set(values)];
+}
+
+module.exports = uniqueValues;
+
+if (require.main === module) {
+  const values = ["apple", "banana", "apple", "pear", "banana"];
+  console.log(uniqueValues(values));
+  // Expected output: [ 'apple', 'banana', 'pear' ]
+}


### PR DESCRIPTION
## Summary
- add a reusable `uniqueValues` helper for deduplicating arrays while preserving first-seen order
- validate the input and provide a clear error for non-array values
- include a small executable example for quick verification

This complements the existing duplicate-finder example by returning the de-duplicated values themselves.